### PR TITLE
chore: Be verbose on pipeline upload

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -28,5 +28,5 @@ pipeline=$(get_pipeline $post_type)
 if [ -n "$pipeline" ]; then
   echo "Uploading new pipeline"
   echo "$pipeline"
-  echo "$pipeline" | buildkite-agent pipeline upload  > /dev/null 2>&1
+  echo "$pipeline" | buildkite-agent pipeline upload
 fi


### PR DESCRIPTION
To help tracing problems in the configuration, show all the `buildkite-agent pipeline upload` output