### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ The following pipeline will execute `annotate.sh`, wait for completion, and then
 steps:
   - command: test.sh
     plugins:
-      telefonica/post#0.1.1:
-        post:
-          - when: failure
-            # steps is a string, note the `|`
-            steps: |
-              - command: email.sh
-              - wait
-              - command: clenaup.sh
-          - when: success
-            # steps is a string, note the `|`
-            steps: |
-              - command: slack.sh
+      - telefonica/post#0.1.1:
+          post:
+            - when: failure
+              # steps is a string, note the `|`
+              steps: |
+                - command: email.sh
+                - wait
+                - command: clenaup.sh
+            - when: success
+              # steps is a string, note the `|`
+              steps: |
+                - command: slack.sh
 ```
 
 ## How it works
@@ -57,14 +57,14 @@ This **does not** work
 steps:
   - command: test.sh
     plugins:
-      telefonica/post#0.1.1:
-        post:
-          - when: failure
-            steps: |
-              - command: annotate.sh
-              - command: email.sh
-              - wait
-              - command: clenaup.sh
+      - telefonica/post#0.1.1:
+          post:
+            - when: failure
+              steps: |
+                - command: annotate.sh
+                - command: email.sh
+                - wait
+                - command: clenaup.sh
 ```
 
 But are allowed when not using `wait`
@@ -75,13 +75,13 @@ This work
 steps:
   - command: test.sh
     plugins:
-      telefonica/post#0.1.1:
-        post:
-          - when: failure
-            steps: |
-              - command: annotate.sh
-              - command: email.sh
-              - command: clenaup.sh
+      - telefonica/post#0.1.1:
+          post:
+            - when: failure
+              steps: |
+                - command: annotate.sh
+                - command: email.sh
+                - command: clenaup.sh
 ```
 
 ## License


### PR DESCRIPTION
Hi @jmendiara! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.